### PR TITLE
Remove es6 templated strings

### DIFF
--- a/lib/flightstats.js
+++ b/lib/flightstats.js
@@ -86,7 +86,7 @@ FlightStats.prototype = {
     options = options != null ? options : {}
 
     var self = this
-    var baseUrl = `${FlightStats.baseUrl}/airlines/rest/v1/json`
+    var baseUrl = FlightStats.baseUrl + '/airlines/rest/v1/json'
     var isCode = options.fs || options.iata || options.icao
     var supportsDate = !options.all || isCode
 
@@ -110,7 +110,7 @@ FlightStats.prototype = {
       var month = options.date.getMonth() + 1
       var day = options.date.getDate()
 
-      baseUrl += `/${year}/${month}/${day}`
+      baseUrl += '/' + year + '/' + month + '/' + day
 
     }
 
@@ -200,7 +200,7 @@ FlightStats.prototype = {
 
     var protocol = options.protocol || 'rest'
     var format = options.format || 'json'
-    var baseUrl = `${FlightStats.baseUrl}/flightstatus/${protocol}/v2/${format}/flight/status`
+    var baseUrl = FlightStats.baseUrl + '/flightstatus/' + protocol + '/v2/' + format + '/flight/status'
 
     var carrier = options.airlineCode
     var flightNumber = options.flightNumber
@@ -222,7 +222,7 @@ FlightStats.prototype = {
 
     return request({
       headers: Object.assign( {}, this.headers, options.headers || void 0 ),
-      url: `${baseUrl}/${carrier}/${flightNumber}/${direction}/${year}/${month}/${day}`,
+      url: baseUrl + '/' + carrier + '/' + flightNumber + '/' + direction + '/' + year + '/' + month + '/' + day,
       qs: {
         airport: options.airport || void 0,
         appId: this.options.appId,
@@ -259,7 +259,7 @@ FlightStats.prototype = {
 
     var protocol = options.protocol || 'rest'
     var format = options.format || 'json'
-    var baseUrl = `${FlightStats.baseUrl}/schedules/${protocol}/v1/${format}/flight`
+    var baseUrl = FlightStats.baseUrl + '/schedules/' + protocol + '/v1/' + format + '/flight'
 
     var carrier = options.airlineCode
     var flightNumber = options.flightNumber
@@ -281,7 +281,7 @@ FlightStats.prototype = {
 
     return request({
       headers: Object.assign( {}, this.headers, options.headers || void 0 ),
-      url: `${baseUrl}/${carrier}/${flightNumber}/${direction}/${year}/${month}/${day}`,
+      url: baseUrl + '/' + carrier + '/' + flightNumber + '/' + direction + '/' + year + '/' + month + '/' + day,
       qs: {
         appId: this.options.appId,
         appKey: this.options.apiKey,


### PR DESCRIPTION
Had to remove these in an ES5 project and I figured I might as well offer them upstream.

If you'd like to keep the ES6, feel free to ignore and close the PR.

I also ran the tests with an evaluation key:
<img width="315" alt="screen shot 2016-05-31 at 17 58 48" src="https://cloud.githubusercontent.com/assets/916351/15695181/6984e2d0-2759-11e6-9a8d-156397ae1f6a.png">
