### PR TITLE
Increase default User-Agent header granularity

### DIFF
--- a/lib/flightstats.js
+++ b/lib/flightstats.js
@@ -41,8 +41,7 @@ function FlightStats( options ) {
  */
 FlightStats.defaults = {
   baseUrl: 'https://api.flightstats.com/flex',
-  userAgent: packageInfo.name + '/' + packageInfo.version + ' ' +
-    '(' + process.release.name + '/' + process.versions.node + ')',
+  userAgent: require( './user-agent' ),
 }
 
 FlightStats.AirlineCategory = require( './airline-category' )

--- a/lib/user-agent.js
+++ b/lib/user-agent.js
@@ -1,0 +1,6 @@
+var pkg = require( '../package.json' )
+var os = require( 'os' )
+
+module.exports = pkg.name + '/' + pkg.version + ' ' +
+  '(' + os.platform() + '/' + os.release() + '; ' + os.arch() + '; +' + pkg.homepage + ') ' +
+  process.release.name + '/' + process.versions[process.release.name]


### PR DESCRIPTION
This could make reporting bugs and such easier, should the API provider encounter anomalies.

**Example:**
```
flightstats/0.18.0 (darwin/15.6.0; x64; +https://github.com/jhermsmeier/node-flightstats) node/7.2.1
```