### PR TITLE
Fix verbs for use with the four connection queries

### DIFF
--- a/lib/flightstats.js
+++ b/lib/flightstats.js
@@ -490,7 +490,7 @@ FlightStats.prototype = {
    * @return {Request}
    */
   firstFlightIn: function( options, callback ) {
-    options = Object.assign({ type: 'firstflightin' }, options )
+    options = Object.assign({ type: 'firstflightin', verb: '/arriving_before/' }, options )
     return this.connections( options, callback )
   },
 
@@ -501,7 +501,7 @@ FlightStats.prototype = {
    * @return {Request}
    */
   firstFlightOut: function( options, callback ) {
-    options = Object.assign({ type: 'firstflightout' }, options )
+    options = Object.assign({ type: 'firstflightout', verb: '/leaving_after/' }, options )
     return this.connections( options, callback )
   },
 
@@ -512,7 +512,7 @@ FlightStats.prototype = {
    * @return {Request}
    */
   lastFlightIn: function( options, callback ) {
-    options = Object.assign({ type: 'lastflightin' }, options )
+    options = Object.assign({ type: 'lastflightin', verb: '/arriving_before/' }, options )
     return this.connections( options, callback )
   },
 
@@ -523,7 +523,7 @@ FlightStats.prototype = {
    * @return {Request}
    */
   lastFlightOut: function( options, callback ) {
-    options = Object.assign({ type: 'lastflightout' }, options )
+    options = Object.assign({ type: 'lastflightout', verb: '/leaving_after/' }, options )
     return this.connections( options, callback )
   },
 
@@ -562,7 +562,7 @@ FlightStats.prototype = {
     var minute = options.date.getMinutes()
 
     var url = '/connections/rest/v2/json/' + options.type + '/' + options.departureAirport + '/to/' + options.arrivalAirport +
-      '/arriving_before/' + year + '/' + month + '/' + day + '/' + hour + '/' + minute
+      options.verb + year + '/' + month + '/' + day + '/' + hour + '/' + minute
 
     var extensions = []
 


### PR DESCRIPTION
The API seems to strictly require the `leaving_after` and `arriving_before`
verbs to match up with the firstin/lastout query types for connections
as per the [Flex API documentation examples](https://developer.flightstats.com/api-docs/connections/v2). Without this, the two types
which appear to require the use of "`leaving_after`" always return 404.

Signed-off-by: Phil Estes <estesp@gmail.com>