### PR TITLE
fix typo in docs while config new flightstate object

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -51,7 +51,7 @@
     - [.baseUrl] <code>String</code> <code> = &#x27;https://api.flightstats.com/flex&#x27;</code> - optional
     - .userAgent <code>String</code> - optional
     - .appId <code>String</code>
-    - .appKey <code>String</code>
+    - .apiKey <code>String</code>
 
 
 * * *


### PR DESCRIPTION
typo fix in following section of docs
[https://github.com/uzaif313/node-flightstats/blob/master/docs/API.md#new-flightstatsoptions](Link)
